### PR TITLE
Fix language standard option

### DIFF
--- a/Mile.Project.Cpp.props
+++ b/Mile.Project.Cpp.props
@@ -24,9 +24,9 @@
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard Condition="'$(PlatformToolsetVersion)' == '143'">stdcpp20</LanguageStandard>
-      <LanguageStandard Condition="'$(PlatformToolsetVersion)' == '142'">stdcpp17</LanguageStandard>
-      <LanguageStandard_C Condition="'$(PlatformToolsetVersion)' == '143'">stdc17</LanguageStandard_C>
+      <LanguageStandard Condition="'$(PlatformToolsetVersion)' >= '143' and '$(LanguageStandard)' == ''">stdcpp20</LanguageStandard>
+      <LanguageStandard Condition="'$(PlatformToolsetVersion)' == '142' and '$(LanguageStandard)' == ''">stdcpp17</LanguageStandard>
+      <LanguageStandard_C Condition="'$(PlatformToolsetVersion)' >= '143' and '$(LanguageStandard)' == ''">stdc17</LanguageStandard_C>
       <PreprocessorDefinitions>_MILE_PROJECT_BUILD_DATE=$(MileProjectBuildDate);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions>$(MileProjectPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)' == 'Win32'">WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
- Don't set language standard if it is set by the user.
- Use greater-than platform toolset version for compatibility with VS2026 and greater.